### PR TITLE
Register 테스트 작성

### DIFF
--- a/instagram-adapter/build.gradle
+++ b/instagram-adapter/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api project(':instagram-data')
+    implementation project(':instagram-data')
     api project(':instagram-application')
 
     implementation group: 'com.maxmind.geoip2', name: 'geoip2', version: '2.3.1'

--- a/instagram-adapter/build.gradle
+++ b/instagram-adapter/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation project(':instagram-data')
+    api project(':instagram-data')
     api project(':instagram-application')
 
     implementation group: 'com.maxmind.geoip2', name: 'geoip2', version: '2.3.1'

--- a/instagram-adapter/build.gradle
+++ b/instagram-adapter/build.gradle
@@ -1,11 +1,12 @@
 dependencies {
-    implementation project(':instagram-data')
+    api project(':instagram-data')
     api project(':instagram-application')
 
     implementation group: 'com.maxmind.geoip2', name: 'geoip2', version: '2.3.1'
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.0.1.RELEASE'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '1.2.0.RELEASE'
 
+    testImplementation 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/instagram-adapter/src/test/java/clone/instagram/TestApplication.java
+++ b/instagram-adapter/src/test/java/clone/instagram/TestApplication.java
@@ -1,0 +1,8 @@
+package clone.instagram;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TestApplication {
+
+}

--- a/instagram-adapter/src/test/java/clone/instagram/member/out/adapter/MemberPersistentAdapterTest.java
+++ b/instagram-adapter/src/test/java/clone/instagram/member/out/adapter/MemberPersistentAdapterTest.java
@@ -1,0 +1,57 @@
+package clone.instagram.member.out.adapter;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import clone.instagram.error.exception.member.MemberNotFoundException;
+import clone.instagram.jpa.mapper.ImageMapper;
+import clone.instagram.jpa.mapper.MemberMapper;
+import clone.instagram.member.Member;
+
+@DataJpaTest
+@Import({ImageMapper.class, MemberMapper.class, MemberPersistentAdapter.class})
+public class MemberPersistentAdapterTest {
+
+	@Autowired
+	private MemberPersistentAdapter memberPersistentAdapter;
+
+	@Nested
+	@DisplayName("loadMemberByUsername()")
+	class LoadMemberByUsername {
+
+		@Test
+		@Sql("classpath:BaseMember.sql")
+		void validArguments_ReturnMember() {
+			// given
+
+			// when
+			final Member member = memberPersistentAdapter.loadMemberByUsername("agent_username");
+
+			// then
+			assertThat(member.getUsername()).isEqualTo("agent_username");
+		}
+
+		@Test
+		@Sql("classpath:BaseMember.sql")
+		void usernameNotFound_ThrowException() {
+			// given
+
+			// when
+			final ThrowableAssert.ThrowingCallable executable =
+				() -> memberPersistentAdapter.loadMemberByUsername("no_username");
+
+			// then
+			assertThatThrownBy(executable).isInstanceOf(MemberNotFoundException.class);
+		}
+
+	}
+
+}

--- a/instagram-adapter/src/test/resources/BaseMember.sql
+++ b/instagram-adapter/src/test/resources/BaseMember.sql
@@ -1,0 +1,5 @@
+insert into members(username, password, name, email, gender, introduce, phone, website, image_name, image_type, image_uuid, image_url)
+    values('agent_username', 'password', 'agent_name', 'agent@email.com', 'PRIVATE', 'introduce', 'phone', 'website', 'image_name', 'PNG', 'image_uuid', 'image_url');
+
+insert into members(username, password, name, email, gender, introduce, phone, website, image_name, image_type, image_uuid, image_url)
+values('target_username', 'password', 'target_name', 'target@email.com', 'PRIVATE', 'introduce', 'phone', 'website', 'image_name', 'PNG', 'image_uuid', 'image_url');

--- a/instagram-api/build.gradle
+++ b/instagram-api/build.gradle
@@ -10,4 +10,9 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    testImplementation 'com.h2database:h2'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }

--- a/instagram-api/src/test/java/clone/instagram/member/controller/RegisterControllerTest.java
+++ b/instagram-api/src/test/java/clone/instagram/member/controller/RegisterControllerTest.java
@@ -1,0 +1,47 @@
+package clone.instagram.member.controller;
+
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import clone.instagram.member.BaseMemberImageProperty;
+import clone.instagram.member.port.in.RegisterUseCase;
+
+@WebMvcTest(controllers = RegisterController.class)
+public class RegisterControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private RegisterUseCase registerUseCase;
+
+	@MockBean
+	private BaseMemberImageProperty baseMemberImageProperty;
+
+	@Test
+	void validArguments_Invoke() throws Exception {
+		// given
+		final String request = "{"
+			+ "\"username\":\"agent\", \"name\":\"name\", \"password\":\"password\", \"email\":\"agent@email.com\""
+			+ "}";
+		given(registerUseCase.invoke(any())).willReturn(true);
+
+		// when
+		mockMvc.perform(MockMvcRequestBuilders.post("/accounts")
+				.content(request)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(MockMvcResultMatchers.status().isCreated());
+
+		// then
+		then(registerUseCase).should().invoke(any());
+	}
+
+}

--- a/instagram-application/build.gradle
+++ b/instagram-application/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     api project(':instagram-domain')
 
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.bootJar { enabled = false }

--- a/instagram-application/src/test/java/clone/instagram/member/service/RegisterServiceTest.java
+++ b/instagram-application/src/test/java/clone/instagram/member/service/RegisterServiceTest.java
@@ -3,12 +3,9 @@ package clone.instagram.member.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import org.assertj.core.api.Assertions;
-import org.assertj.core.api.ThrowableAssert;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -18,7 +15,6 @@ import clone.instagram.member.BaseMemberImageProperty;
 import clone.instagram.member.port.in.RegisterUseCase;
 import clone.instagram.member.port.out.LoadMemberByUsernamePort;
 import clone.instagram.member.port.out.SaveMemberPort;
-import clone.instagram.member.service.RegisterService;
 
 @ExtendWith(MockitoExtension.class)
 public class RegisterServiceTest {

--- a/instagram-application/src/test/java/clone/instagram/member/service/RegisterServiceTest.java
+++ b/instagram-application/src/test/java/clone/instagram/member/service/RegisterServiceTest.java
@@ -1,0 +1,72 @@
+package clone.instagram.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import clone.instagram.error.exception.member.UsernameAlreadyExistException;
+import clone.instagram.member.BaseMemberImageProperty;
+import clone.instagram.member.port.in.RegisterUseCase;
+import clone.instagram.member.port.out.LoadMemberByUsernamePort;
+import clone.instagram.member.port.out.SaveMemberPort;
+import clone.instagram.member.service.RegisterService;
+
+@ExtendWith(MockitoExtension.class)
+public class RegisterServiceTest {
+
+	@InjectMocks
+	private RegisterService registerService;
+
+	@Mock
+	private LoadMemberByUsernamePort loadMemberPort;
+
+	@Mock
+	private SaveMemberPort saveMemberPort;
+
+	@Mock
+	private BaseMemberImageProperty baseMemberImageProperty;
+
+	@Test
+	void validArguments_CallSaveMember() {
+		// given
+		final String username = "username";
+		final RegisterUseCase.Command.ToRegisterInfo command
+			= new RegisterUseCase.Command.ToRegisterInfo(
+			username, "password", "name", "email", baseMemberImageProperty
+		);
+
+		// when
+		final boolean result = registerService.invoke(command);
+
+		// then
+		then(saveMemberPort).should().saveMember(any());
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	void usernameExists_ThrowException() {
+		// given
+		final String username = "username";
+		final RegisterUseCase.Command.ToRegisterInfo command
+			= new RegisterUseCase.Command.ToRegisterInfo(
+			username, "password", "name", "email", baseMemberImageProperty
+		);
+		given(loadMemberPort.existsMemberByUsername(username)).willReturn(true);
+
+		// when
+		final ThrowingCallable executable = () -> registerService.invoke(command);
+
+		// then
+		assertThatThrownBy(executable).isInstanceOf(UsernameAlreadyExistException.class);
+	}
+
+}


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
### 테스트용 gradle 의존성 수정
- 테스트 대상 모듈에 `spring-boot-starter-test` 의존성 추가 
- DB와의 연결이 필요한 모듈(`adapter`)에  `h2` 관련 테스트 의존성 추가
- 추가로 `adapter` 모듈에서 `data`의 클래스를 주입받을 때 정상 실행은 되지만 인텔리제이에서 *밑줄*이 표시되는 이슈가 있었습니다. `adapter`모듈에서 `data`에 대한 의존을 `implementation`에서 `api`로 수정하니 해결됐습니다!

### Register 테스트 작성
- `Adapter`의 경우 내부에 여러 메서드를 포함하고 있으므로 `@Nested` 클래스를 활용하였습니다.(이전 프로젝트의 컨벤션과 같음)
  - Controller와 Service의 경우 하나의 public 메서드만 가지므로 `@Nested`는 사용하지 않았습니다.
- DB에 테스트를 위한 초기 정보가 필요한 경우(adapter, data) `@Sql`을 활용하였습니다.
  - `@BeforeEach`와 같은 메서드를 활용할 수도 있으나 코드가 길어지며 중복 코드가 너무 많아진다고 판단하였습니다.
  -  *중복코드*는 예를들면 기본 `Member` 생성과 같은  작업을 의미합니다. 대부분의 로직이 유저 간의 상호작용을 가지므로, 매 테스트 시 마다 `Member`를 생성하여야 하고 이는 중복코드가 너무 많아진다고 생각했습니다.
- 코드 간의 상호작용이 있거나 예외 처리를 가지는 `adapter`, `api`, `application` 모듈만 테스트를 작성하였습니다.
  - `domain` 모듈의 경우 현재 테스트할만한 로직이 없어서, 추후에 복잡한 로직이 추가될 경우 테스트를 작성하겠습니다.
  -  `data`모듈도 현재 단순한 `JpaRepository`만을 가지므로 작성하지 않았습니다. 추후에 querydsl, JPQL 사용 시에 테스트를 작성할 것 같습니다.

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
